### PR TITLE
corrected "Cancel Order Status" value

### DIFF
--- a/upload/admin/view/template/extension/payment/paywithiyzico.twig
+++ b/upload/admin/view/template/extension/payment/paywithiyzico.twig
@@ -65,7 +65,7 @@
                         <div class="col-sm-10">
                             <select class="form-control" name="payment_paywithiyzico_order_cancel_status">
                                 {% for order_status in order_statuses %}
-                                    {% if order_status.order_status_id == payment_paywithpaywithiyzico_order_cancel_status %}
+                                    {% if order_status.order_status_id == payment_paywithiyzico_order_cancel_status %}
                                         <option value="{{ order_status.order_status_id }}" selected="selected">{{ order_status.name }}</option>
                                     {% else %}
                                         {% if payment_paywithiyzico_order_status == false and order_status.order_status_id == 7  %}


### PR DESCRIPTION
Twig dosyasında ufak bir düzeltme yaptım. Admin sayfasında Cancel Order Status seçeneği doğru gösterilmiyordu çünkü. Listeden hangi seçenek seçilirse seçilsin, kaydedilip sayfa tekrar açıldığında listedeki ilk öğeyi gösteriyor, bu da kafa karıştırıyordu.